### PR TITLE
Optimize WiFi connection time by using WIFI_FAST_SCAN

### DIFF
--- a/components/wifiManager/wifiManager/wifiManager.cpp
+++ b/components/wifiManager/wifiManager/wifiManager.cpp
@@ -102,7 +102,12 @@ void WiFiManager::ConnectWithHardcodedCredentials()
 {
   SystemEvent event = {EventSource::WIFI, WiFiState_e::WiFiState_ReadyToConnect};
   this->SetCredentials(CONFIG_WIFI_SSID, CONFIG_WIFI_PASSWORD);
-  // Skip esp_wifi_stop() on first connection - WiFi not started yet
+
+  wifi_mode_t mode;
+  if (esp_wifi_get_mode(&mode) == ESP_OK) {
+    esp_wifi_stop();
+  }
+
   ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
   ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &_wifi_cfg));
 


### PR DESCRIPTION
### Summary

Optimizes WiFi connection startup time in wifiManager.cpp by switching from full channel scan to fast scan mode.

**Before:** WiFi connected at ~6279ms  
**After:** WiFi connected at ~3897ms  
**Improvement:** ~2000ms faster


### Changes

**File:** wifiManager.cpp

#### 1. Switch to `WIFI_FAST_SCAN` mode

```cpp
// Changed from WIFI_ALL_CHANNEL_SCAN to WIFI_FAST_SCAN
_wifi_cfg.sta.scan_method = WIFI_FAST_SCAN;
```

**Why `WIFI_FAST_SCAN` is faster:**

| Mode | Behavior | Time |
|------|----------|------|
| `WIFI_ALL_CHANNEL_SCAN` | Scans all 14 channels (~100ms each), collects all matching APs, then selects the best one | ~1.5-3s |
| `WIFI_FAST_SCAN` | Stops scanning immediately when first matching AP is found | ~100-500ms |

**Trade-off:** May not connect to the strongest AP if multiple APs share the same SSID. This is acceptable for typical single-AP home/lab environments where this eye tracker operates.

#### 2.Check whether WIFI is open before closing

```cpp
wifi_mode_t mode;
if (esp_wifi_get_mode(&mode) == ESP_OK) {
  esp_wifi_stop();
}
```

First connection - WiFi hasn't started yet. Check whether WIFI is open before closing

#### 3. Reduce connection timeout

Changed `portMAX_DELAY` to `pdMS_TO_TICKS(8000)` for hardcoded credentials connection. This doesn't affect successful connection time but prevents indefinite blocking on failures.

### Testing

- Tested with WPA2-PSK network
- Device: wrooms3QIO
- CONFIG_GENERAL_ENABLE_WIRELESS=y
- Mode: WiFi

