### PR TITLE
refactor(Monitoring): abstract platform-specific ADC code and add ESP32-S2 support

### DIFF
--- a/components/Monitoring/CMakeLists.txt
+++ b/components/Monitoring/CMakeLists.txt
@@ -9,14 +9,30 @@
 # +-----------------------+
 # |   ESP-IDF ADC HAL     | ← Espressif official driver
 # +-----------------------+
+#
+# Supported platforms (must support ESP-CAM):
+# - ESP32:    Tested
+# - ESP32-S3: Tested
+# - ESP32-S2: UNTESTED - Based on datasheet
 
 set(
   requires
   Helpers
 )
 
+# List of supported ADC platforms (aligned with ESP_CAMERA_SUPPORTED)
+set(ADC_SUPPORTED_TARGETS "esp32" "esp32s3" "esp32s2")
+
+# Check if current target supports ADC
+list(FIND ADC_SUPPORTED_TARGETS "$ENV{IDF_TARGET}" ADC_TARGET_INDEX)
+if (NOT ADC_TARGET_INDEX EQUAL -1)
+  set(ADC_SAMPLER_SUPPORTED TRUE)
+else()
+  set(ADC_SAMPLER_SUPPORTED FALSE)
+endif()
+
 # Platform-specific dependencies
-if ("$ENV{IDF_TARGET}" STREQUAL "esp32s3" OR "$ENV{IDF_TARGET}" STREQUAL "esp32")
+if (ADC_SAMPLER_SUPPORTED)
 list(APPEND requires
             driver 
             esp_adc
@@ -32,22 +48,20 @@ set(
 )
 
 # BSP Layer: ADC sampler implementation
-if ("$ENV{IDF_TARGET}" STREQUAL "esp32s3" OR "$ENV{IDF_TARGET}" STREQUAL "esp32")
-# Common ADC implementation
-list(APPEND source_files
-  "Monitoring/AdcSampler.cpp"
+if (ADC_SAMPLER_SUPPORTED)
+  # Common ADC implementation
+  list(APPEND source_files
+    "Monitoring/AdcSampler.cpp"
   )
 
-# Platform-specific GPIO-to-channel mapping
-if ("$ENV{IDF_TARGET}" STREQUAL "esp32s3")
-  list(APPEND source_files
-    "Monitoring/AdcSampler_esp32s3.cpp"
-  )
-elseif ("$ENV{IDF_TARGET}" STREQUAL "esp32")
-  list(APPEND source_files
-    "Monitoring/AdcSampler_esp32.cpp"
-  )
-endif()
+  # Platform-specific GPIO-to-channel mapping and calibration
+  if ("$ENV{IDF_TARGET}" STREQUAL "esp32s3")
+    list(APPEND source_files "Monitoring/AdcSampler_esp32s3.cpp")
+  elseif ("$ENV{IDF_TARGET}" STREQUAL "esp32s2")
+    list(APPEND source_files "Monitoring/AdcSampler_esp32s2.cpp")
+  elseif ("$ENV{IDF_TARGET}" STREQUAL "esp32")
+    list(APPEND source_files "Monitoring/AdcSampler_esp32.cpp")
+  endif()
 endif()
 
 

--- a/components/Monitoring/Monitoring/AdcSampler_esp32.cpp
+++ b/components/Monitoring/Monitoring/AdcSampler_esp32.cpp
@@ -1,6 +1,6 @@
 /**
  * @file AdcSampler_esp32.cpp
- * @brief BSP Layer - ESP32 specific GPIO to ADC channel mapping
+ * @brief BSP Layer - ESP32 specific ADC implementation
  *
  * ESP32 ADC1 GPIO mapping:
  * - GPIO32 → ADC1_CH4
@@ -54,6 +54,22 @@ bool AdcSampler::map_gpio_to_channel(int gpio, adc_unit_t& unit, adc_channel_t& 
         channel = ADC_CHANNEL_0;
         return false;
     }
+}
+
+bool AdcSampler::create_calibration(adc_cali_handle_t* handle)
+{
+    // ESP32 uses line fitting calibration (per-unit, not per-channel)
+    adc_cali_line_fitting_config_t cal_cfg = {
+        .unit_id = unit_,
+        .atten = atten_,
+        .bitwidth = bitwidth_,
+    };
+    return adc_cali_create_scheme_line_fitting(&cal_cfg, handle) == ESP_OK;
+}
+
+void AdcSampler::delete_calibration(adc_cali_handle_t handle)
+{
+    adc_cali_delete_scheme_line_fitting(handle);
 }
 
 #endif  // CONFIG_IDF_TARGET_ESP32

--- a/components/Monitoring/Monitoring/AdcSampler_esp32s2.cpp
+++ b/components/Monitoring/Monitoring/AdcSampler_esp32s2.cpp
@@ -1,8 +1,11 @@
 /**
- * @file AdcSampler_esp32s3.cpp
- * @brief BSP Layer - ESP32-S3 specific ADC implementation
+ * @file AdcSampler_esp32s2.cpp
+ * @brief BSP Layer - ESP32-S2 specific ADC implementation
  *
- * ESP32-S3 ADC1 GPIO mapping:
+ *  UNTESTED - This implementation is based on ESP32-S2 datasheet.
+ *             Please verify on actual hardware before production use.
+ *
+ * ESP32-S2 ADC1 GPIO mapping:
  * - GPIO1  → ADC1_CH0
  * - GPIO2  → ADC1_CH1
  * - GPIO3  → ADC1_CH2
@@ -15,17 +18,18 @@
  * - GPIO10 → ADC1_CH9
  *
  * Note: ADC2 is not used to avoid conflicts with Wi-Fi.
+ *       Same as ESP32-S3 implementation.
  */
 
 #include "AdcSampler.hpp"
 
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
 
 bool AdcSampler::map_gpio_to_channel(int gpio, adc_unit_t& unit, adc_channel_t& channel)
 {
     unit = ADC_UNIT_1;  // Only use ADC1 to avoid Wi-Fi conflict
 
-    // ESP32-S3: ADC1 on GPIO1–10 → CH0–CH9
+    // ESP32-S2: ADC1 on GPIO1–10 → CH0–CH9
     if (gpio >= 1 && gpio <= 10)
     {
         channel = static_cast<adc_channel_t>(gpio - 1);
@@ -38,7 +42,7 @@ bool AdcSampler::map_gpio_to_channel(int gpio, adc_unit_t& unit, adc_channel_t& 
 
 bool AdcSampler::create_calibration(adc_cali_handle_t* handle)
 {
-    // ESP32-S3 uses curve fitting calibration
+    // ESP32-S2 uses curve fitting calibration
     adc_cali_curve_fitting_config_t cal_cfg = {
         .unit_id = unit_,
         .chan = channel_,
@@ -53,4 +57,4 @@ void AdcSampler::delete_calibration(adc_cali_handle_t handle)
     adc_cali_delete_scheme_curve_fitting(handle);
 }
 
-#endif  // CONFIG_IDF_TARGET_ESP32S3
+#endif  // CONFIG_IDF_TARGET_ESP32S2


### PR DESCRIPTION
refactor(Monitoring): abstract platform-specific ADC code and add ESP32-S2 support

- Move calibration functions to platform-specific files
- Add ADC_SAMPLER_SUPPORTED macro for unified platform detection
- Add ESP32-S2 support (UNTESTED)
- Remove explicit #if defined() macros from common code