### PR TITLE
Thermal + WiFi reliability changes

### DIFF
--- a/boards/seed_studio/xiao_esp32s3
+++ b/boards/seed_studio/xiao_esp32s3
@@ -2,7 +2,16 @@ CONFIG_IDF_TARGET="esp32s3"
 CONFIG_IDF_TARGET_ESP32S3=y
 CONFIG_LED_DEBUG_GPIO=21
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
-CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+# CPU at 160MHz instead of the 240MHz in sdkconfig.base_defaults, to cut heat.
+# ESP_DEFAULT_CPU_FREQ_MHZ* are the authoritative symbols; the ESP32S3_* names are legacy
+# aliases. switchBoardType.py merges base and board configs by exact key, so the 240 entries
+# have to be turned off explicitly here - omitting them just leaves the base values in place.
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=n
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_160=y
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=160
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=n
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_160=y
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ=160
 CONFIG_ESP32S3_SPIRAM_SUPPORT=y
 CONFIG_SPIRAM_MODE_OCT=y
 # CONFIG_ESPTOOLPY_FLASHSIZE_1MB is not set

--- a/components/CameraManager/CameraManager/CameraManager.cpp
+++ b/components/CameraManager/CameraManager/CameraManager.cpp
@@ -48,8 +48,18 @@ void CameraManager::setupCameraPinout()
     ESP_LOGI(CAMERA_MANAGER_TAG, "CAM_BOARD");
 #endif
 #if CONFIG_GENERAL_INCLUDE_UVC_MODE
-    xclk_freq_hz = CONFIG_CAMERA_USB_XCLK_FREQ;
+    // Pick the clock from the mode the device will actually run in, not from whether UVC
+    // support happens to be compiled in. Choosing at compile time meant every build with
+    // UVC enabled ran the sensor at the USB clock even in WiFi mode, which left
+    // CAMERA_WIFI_XCLK_FREQ dead. Mode is loaded before streaming starts, and switching
+    // modes already requires a reboot, so this is settled by the time the camera comes up.
+    if (projectConfig->getDeviceMode() == StreamingMode::UVC)
+    {
+        xclk_freq_hz = CONFIG_CAMERA_USB_XCLK_FREQ;
+    }
 #endif
+
+    ESP_LOGI(CAMERA_MANAGER_TAG, "[Camera]: XCLK set to %d Hz", xclk_freq_hz);
 
     config = {
         .pin_pwdn = CONFIG_PWDN_GPIO_NUM,      // CAM_PIN_PWDN,

--- a/components/wifiManager/wifiManager/wifiManager.cpp
+++ b/components/wifiManager/wifiManager/wifiManager.cpp
@@ -26,9 +26,10 @@ void WiFiManagerHelpers::event_handler(void* arg, esp_event_base_t event_base, i
 
         if (s_retry_num < EXAMPLE_ESP_MAXIMUM_RETRY)
         {
+            vTaskDelay(pdMS_TO_TICKS(WIFI_RETRY_BACKOFF_MS));
             esp_wifi_connect();
             s_retry_num++;
-            ESP_LOGI(WIFI_MANAGER_TAG, "retry to connect to the AP");
+            ESP_LOGI(WIFI_MANAGER_TAG, "retry %d/%d to connect to the AP", s_retry_num, EXAMPLE_ESP_MAXIMUM_RETRY);
         }
         else
         {
@@ -49,6 +50,27 @@ void WiFiManagerHelpers::event_handler(void* arg, esp_event_base_t event_base, i
 WiFiManager::WiFiManager(std::shared_ptr<ProjectConfig> deviceConfig, QueueHandle_t eventQueue, StateManager* stateManager)
     : deviceConfig(deviceConfig), eventQueue(eventQueue), stateManager(stateManager), wifiScanner(std::make_unique<WiFiScanner>())
 {
+}
+
+void WiFiManager::ApplyTxPower()
+{
+    // esp_wifi_set_max_tx_power only takes effect once the driver is started - calling it
+    // before esp_wifi_start() is silently ignored. Units are 0.25dBm, valid range 8-84.
+    uint8_t configured = this->deviceConfig->getWiFiTxPowerConfig().power;
+    if (configured < 8)
+        configured = 8;
+    if (configured > 84)
+        configured = 84;
+
+    if (const auto err = esp_wifi_set_max_tx_power(static_cast<int8_t>(configured)); err != ESP_OK)
+    {
+        ESP_LOGW(WIFI_MANAGER_TAG, "Failed to set TX power to %u: %s", configured, esp_err_to_name(err));
+        return;
+    }
+
+    int8_t applied = 0;
+    esp_wifi_get_max_tx_power(&applied);
+    ESP_LOGI(WIFI_MANAGER_TAG, "TX power set to %d (%d.%02d dBm)", applied, applied / 4, (applied % 4) * 25);
 }
 
 std::vector<uint8_t> WiFiManager::ParseBSSID(std::string_view bssid_string)
@@ -108,8 +130,10 @@ void WiFiManager::SetCredentials(const char* ssid, const std::vector<uint8_t> bs
     _wifi_cfg.sta.pmf_cfg.capable = false;
     _wifi_cfg.sta.pmf_cfg.required = false;
 
-    // OPTIMIZATION: Use fast scan instead of all channel scan for quicker connection
-    _wifi_cfg.sta.scan_method = WIFI_FAST_SCAN;
+    // IMPORTANT: Must be ALL_CHANNEL_SCAN for sort_method below to take effect. WIFI_FAST_SCAN
+    // stops at the first SSID match, so on a mesh/repeater network it latches onto whichever
+    // node answers the probe first - often a distant one - and association becomes a coin flip.
+    _wifi_cfg.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
     _wifi_cfg.sta.bssid_set = use_bssid;  // Don't use specific BSSID
     _wifi_cfg.sta.channel = 0;            // Auto channel detection
 
@@ -144,12 +168,14 @@ void WiFiManager::ConnectWithHardcodedCredentials()
 
     xQueueSend(this->eventQueue, &event, 10);
     esp_wifi_start();
+    this->ApplyTxPower();
 
     event.value = WiFiState_e::WiFiState_Connecting;
     xQueueSend(this->eventQueue, &event, 10);
 
-    // Use shorter timeout for faster startup - 8 seconds should be enough for most networks
-    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT, pdFALSE, pdFALSE, pdMS_TO_TICKS(8000));
+    // Budget must cover EXAMPLE_ESP_MAXIMUM_RETRY attempts: an all-channel scan costs ~2-3s per
+    // attempt, so timing out earlier than that abandons retries that were about to succeed.
+    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT, pdFALSE, pdFALSE, pdMS_TO_TICKS(18000));
 
     /* xEventGroupWaitBits() returns the bits before the call returned, hence we can test which event actually
      * happened. */
@@ -216,12 +242,13 @@ void WiFiManager::ConnectWithStoredCredentials()
             ESP_LOGE(WIFI_MANAGER_TAG, "Failed to start WiFi: %s", esp_err_to_name(start_err));
             continue;
         }
+        this->ApplyTxPower();
 
         event.value = WiFiState_e::WiFiState_Connecting;
         xQueueSend(this->eventQueue, &event, 10);
 
         EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT, pdFALSE, pdFALSE,
-                                               pdMS_TO_TICKS(10000));  // 10 second timeout for faster failover
+                                               pdMS_TO_TICKS(18000));  // must cover all retries, see ConnectWithHardcodedCredentials
         if (bits & WIFI_CONNECTED_BIT)
         {
             ESP_LOGI(WIFI_MANAGER_TAG, "connected to ap SSID:%s", network.ssid.c_str());

--- a/components/wifiManager/wifiManager/wifiManager.hpp
+++ b/components/wifiManager/wifiManager/wifiManager.hpp
@@ -16,7 +16,10 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#define EXAMPLE_ESP_MAXIMUM_RETRY 3
+#define EXAMPLE_ESP_MAXIMUM_RETRY 5
+// Spacing between reconnect attempts. Retrying with no gap burns the whole retry budget in
+// under a second, which is not enough time for a busy or distant AP to answer.
+#define WIFI_RETRY_BACKOFF_MS 300
 #define WIFI_CONNECTED_BIT BIT0
 #define WIFI_FAIL_BIT BIT1
 
@@ -41,6 +44,7 @@ class WiFiManager
 
     int8_t power;
 
+    void ApplyTxPower();
     void SetCredentials(const char* ssid, const std::vector<uint8_t> bssid, const char* password, bool use_bssid);
     void ConnectWithHardcodedCredentials();
     void ConnectWithStoredCredentials();


### PR DESCRIPTION
# Thermal + WiFi reliability changes

## The following changes have been proven to locally drop temperatures (camera OV3660 and ESP monitored) from 155F+ to 110F, still with amazing performance and reliability with no visual degradation in tracking under same real-world scenarios locally ##

<img width="2160" height="2880" alt="IMG_2441" src="https://github.com/user-attachments/assets/3aa70533-2fcb-44f6-98e0-4114903b1c59" />

## Summary

Changes aimed at reducing heat and making WiFi association deterministic on mesh networks.

Two of these are bugs where an existing setting silently did nothing:

- **`esp_wifi_set_max_tx_power()` is never called anywhere in the firmware**, so every board has always transmitted at the PHY default of 20 dBm — even though `WiFiTxPower_t` already loads a 13 dBm default from NVS, saves it, and exposes it through `get_config`. Both `getWiFiTxPowerConfig()` and `setWiFiTxPower()` had zero callers.
- **`CONFIG_CAMERA_WIFI_XCLK_FREQ` is dead on any build with UVC compiled in**, because the camera clock was selected with `#if` at compile time rather than from the mode the device actually runs in.

| File | Affects |
|---|---|
| `components/wifiManager/wifiManager/wifiManager.cpp` | **All boards** |
| `components/wifiManager/wifiManager/wifiManager.hpp` | **All boards** |
| `components/CameraManager/CameraManager/CameraManager.cpp` | **All boards with UVC compiled in** |
| `boards/seed_studio/xiao_esp32s3` | XIAO ESP32S3 only |

---

## Changes

### 1. Apply the configured WiFi TX power

Adds `WiFiManager::ApplyTxPower()`, called after each `esp_wifi_start()` on the station paths. It must come *after* start — calling it earlier is silently ignored by the driver. The value is clamped to the driver's valid 8–84 range (0.25 dBm units) and the applied result is read back and logged.

20 dBm → 13 dBm is a 7 dB cut: roughly 5× less radiated power and a substantial reduction in PA dissipation.

AP mode is deliberately left at full power — it's the setup-fallback hotspot where range matters, and it doesn't run in steady state.

### 2. `WIFI_FAST_SCAN` → `WIFI_ALL_CHANNEL_SCAN`

`SetCredentials()` sets `sort_method = WIFI_CONNECT_AP_BY_SIGNAL` with the comment *"Connect to strongest signal"* — but `scan_method` was `WIFI_FAST_SCAN`. Per the IDF header:

```c
WIFI_FAST_SCAN = 0,      /**< Do fast scan, scan will end after find SSID match AP */
WIFI_ALL_CHANNEL_SCAN,   /**< All channel scan, scan will end after scan all the channel */
```

Fast scan stops at the first SSID match, so there's no scan list left to sort and `sort_method` is a no-op. On mesh/repeater networks the device associates with whichever node answers the probe first, which varies between boots. On my test network the same SSID was visible at **−50 dBm and −84 dBm**; landing on the far node makes association unreliable.

Costs ~1–2 s more at boot.

### 3. Retry budget and timeouts

- `EXAMPLE_ESP_MAXIMUM_RETRY` 3 → 5
- New `WIFI_RETRY_BACKOFF_MS` = 300 ms between attempts (previously all retries could fire inside a second, which isn't a real attempt)
- Connect wait timeouts 8 s / 10 s → **18 s**

> [!IMPORTANT]
> **Changes 2 and 3 are coupled — please don't merge one without the other.** An all-channel scan costs ~2–3 s per attempt, so keeping the old 8 s/10 s windows would expire mid-retry and fall through to AP-mode fallback *sooner* than before the change.

### 4. Select camera XCLK from the runtime mode, not the compile flag

`setupCameraPinout()` chose the sensor clock like this:

```c
int xclk_freq_hz = CONFIG_CAMERA_WIFI_XCLK_FREQ;
#if CONFIG_GENERAL_INCLUDE_UVC_MODE
    xclk_freq_hz = CONFIG_CAMERA_USB_XCLK_FREQ;   // compile-time, always wins
#endif
```

Because that's `#if` rather than a runtime check, **any build with UVC support compiled in ran the sensor at the USB clock even while the device was in WiFi mode.** `CONFIG_CAMERA_WIFI_XCLK_FREQ` was effectively unreachable on those builds, and boards paid the higher sensor clock — and the resulting heat — for a mode they weren't in.

Now checks the stored device mode. Mode is loaded before the camera is set up, and switching modes already requires a reboot, so it's settled by then. The selected frequency is also logged, since previously there was no way to confirm from outside what the sensor was actually running at.

### 5. XIAO ESP32S3: CPU 240 MHz → 160 MHz

Scoped to `boards/seed_studio/xiao_esp32s3`, so only that board's artifact changes.

Worth flagging for anyone editing board files later — the obvious one-line edit does **not** work:

```diff
-CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_160=y
```

That still builds at 240 MHz, because:

1. `CONFIG_ESP32S3_DEFAULT_CPU_FREQ_*` is a **legacy alias**; the authoritative symbols are `CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ*`, and setting the alias doesn't propagate.
2. `switchBoardType.py` merges with `{**base, **board}` — a dict merge **by exact key**. `..._240` and `..._160` are different keys, so setting `_160=y` leaves `base_defaults`' `_240=y` in place.

Both `_240` symbols therefore have to be explicitly `=n`. That's the six lines in the diff, with a comment in the board file explaining why.

---

## Testing

Verified on **Seeed XIAO ESP32S3 Sense** (OV3660), ESP-IDF v5.4.4, against a mesh network (two APs, same SSID, −50 dBm and −84 dBm).

### WiFi

Boot log confirms TX power now applies and the device still associates fine at reduced power:

```
I (3348) [WIFI_MANAGER]: TX power set to 52 (13.00 dBm)
I (6876) [WIFI_MANAGER]: got ip:192.168.1.85
I (6880) [WIFI_MANAGER]: connected to ap SSID:<redacted>
```

Reset-to-connected soak, **8/8 cycles connected**, ~9 s each with no variance:

```
t=3.1s  initialized
t=6.2s  connecting
t=9.3s  connected
```

### Camera XCLK

In WiFi mode the sensor clock drops from 23 MHz to 16.5 MHz:

```
I (2238) [CAMERA_MANAGER]: [Camera]: XCLK set to 16500000 Hz
```

I built a control image without this change and compared `cam_hal` warnings on the same hardware across repeated boots:

| | XCLK | `NO-SOI` | `FB-OVF` |
|---|---|---|---|
| **Without change** | 23 MHz | 2× | 4× |
| **With change** | 16.5 MHz | 1× | 0 |

So frame corruption **decreases** — the lower pixel clock leaves more DMA headroom, which is why the frame-buffer overflows disappear entirely.

### CPU frequency

Verified against the compiled output rather than `sdkconfig`, since `confgen` has the final say:

```
build/config/sdkconfig.h:605:#define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ 160
```

---

## Review notes

**Behaviour change for existing users (TX power).** Anyone with a stored `txpower` value will now actually get it, defaulting to 13 dBm instead of the current effective 20 dBm. That's the intent, but it is a change in shipped behaviour. The value is already runtime-configurable — only the plumbing is new. Happy to change the default if 13 dBm is considered too aggressive.

**Behaviour change for OV2640 boards (camera XCLK).** On boards with UVC compiled in, WiFi mode now runs the sensor at `CAMERA_WIFI_XCLK_FREQ` (16.5 MHz by default) instead of the USB value. That's what the config was always meant to do, but it may reduce achievable framerate on OV2640 hardware. I only have an OV3660 to test on. If a lower clock proves too slow for some board, the right fix is raising that board's `CAMERA_WIFI_XCLK_FREQ` rather than reverting to the compile-time behaviour.

**Only hardware-tested on `esp32s3`.** These changes compile-affect all 12 boards in the CI matrix, including the three `esp32` targets, which I have no hardware for. Relying on CI for those.

**No baseline for change 2.** I did not capture a failure rate with `WIFI_FAST_SCAN` before making the change, so this isn't proven to fix a specific field report. The defect is confirmed against the IDF header; the improvement is reasoned rather than measured. Post-change is 8/8 as above.

---

## Not included

**HIL harness defaults produce phantom failures.** `tests/.env.example` ships `SWITCH_MODE_REBOOT_TIME=5`; USB re-enumeration alone measured 2.8 s, and the board isn't responsive for several seconds after that because the serial task runs at priority 1 and gets starved during WiFi association. Compounding it, `OpenIrisDeviceManager.get_device()` silently returns a **stale dead handle** when the port changes instead of raising or retrying, so one timing miss cascades. Raising the default to 8 took a run from 43 failed / 17 passed to **60 passed / 1 skipped** with no firmware change.
